### PR TITLE
feat: add _schema.yml for configuration validation and IDE support

### DIFF
--- a/_extensions/language-cell-decorator/_schema.yml
+++ b/_extensions/language-cell-decorator/_schema.yml
@@ -1,0 +1,12 @@
+# _schema.yml for "language-cell-decorator" filter extension
+# Describes element attributes for IDE tooling and runtime validation.
+
+# Element attributes accepted by the filter on CodeBlock elements.
+# The filter extracts the language from code block classes and decorates the block.
+# It also supports extracting a filename from a special comment syntax:
+#   language | filename: name.ext
+element-attributes:
+  CodeBlock:
+    filename:
+      type: string
+      description: "Filename to display as a decoration label on the code block."


### PR DESCRIPTION
## Summary

- Add `_extensions/language-cell-decorator/_schema.yml` describing the `filename` element attribute on CodeBlock elements for the `language-cell-decorator` filter extension.