### PR TITLE
chore: add $schema version URI to _schema.yml

### DIFF
--- a/_extensions/language-cell-decorator/_schema.yml
+++ b/_extensions/language-cell-decorator/_schema.yml
@@ -5,6 +5,9 @@
 # The filter extracts the language from code block classes and decorates the block.
 # It also supports extracting a filename from a special comment syntax:
 #   language | filename: name.ext
+
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
 element-attributes:
   CodeBlock:
     filename:


### PR DESCRIPTION
## Summary

- Add `$schema` version URI to `_schema.yml` for IDE tooling and validation alignment.

References [quarto-wizard#272](https://github.com/mcanouil/quarto-wizard/pull/272).