### PR TITLE
feat: rename element-attributes to attributes in schema

### DIFF
--- a/_extensions/language-cell-decorator/_schema.yml
+++ b/_extensions/language-cell-decorator/_schema.yml
@@ -1,14 +1,14 @@
 # _schema.yml for "language-cell-decorator" filter extension
-# Describes element attributes for IDE tooling and runtime validation.
+# Describes attributes for IDE tooling and runtime validation.
 
-# Element attributes accepted by the filter on CodeBlock elements.
+# Attributes accepted by the filter on CodeBlock elements.
 # The filter extracts the language from code block classes and decorates the block.
 # It also supports extracting a filename from a special comment syntax:
 #   language | filename: name.ext
 
 $schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
 
-element-attributes:
+attributes:
   CodeBlock:
     filename:
       type: string


### PR DESCRIPTION
## Summary

- Rename the `element-attributes` YAML key to `attributes` in `_schema.yml` to match the updated [Quarto Wizard schema specification](https://m.canouil.dev/quarto-wizard/reference/schema-specification.html).

## Test plan

- [ ] Verify IDE completion and hover still work for element attributes.