### PR TITLE
docs: Deprecate extension in favour of Code Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-No user-facing changes.
+### Documentation
+
+- docs: Deprecate Language Cell Decorator extension in favour of Code Window.
 
 ## 0.3.1 (2026-02-21)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This extension adds a decorator to the code cells to display the language name.
 
+> [!WARNING]
+> This extension has been superseded by the [Code Window extension](https://github.com/mcanouil/quarto-code-window).
+> Code Window shows the language name on code blocks by default and adds window-style decorations.
+> Please update your project to use the new extension.
+>
+> To install the new extension, see the [installation instructions](https://github.com/mcanouil/quarto-code-window?tab=readme-ov-file#installation).
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Marks this extension as superseded by the Code Window extension, which shows the language name on code blocks by default. Adds a notice to the README and a changelog entry.